### PR TITLE
feat: Add Call feedback with Spinner and Toasts

### DIFF
--- a/src/components/call-central/call-central.tsx
+++ b/src/components/call-central/call-central.tsx
@@ -5,6 +5,7 @@ import classes from "./call-central.module.css";
 import { useCall } from "@/context/call.context";
 import { Modal } from "../modal/modal";
 import { ProfilePicture } from "../profile-picture/profile-picture";
+import { Spinner } from "../loaders/spinner/spinner";
 import {
   AudioMuteIcon,
   AudioUnmuteIcon,
@@ -90,9 +91,13 @@ export const CallCentral = () => {
                     scale="large"
                   />
                   {isCallConnecting ? (
-                    <div className={classes.fullName}>
-                      Calling {otherUser.fullName} ...
-                    </div>
+                    <>
+                      <br />
+                      <Spinner />
+                      <div className={classes.fullName}>
+                        Calling {otherUser.fullName} ...
+                      </div>
+                    </>
                   ) : (
                     <div className={classes.fullName}>{otherUser.fullName}</div>
                   )}

--- a/src/components/toasts/toasts.module.css
+++ b/src/components/toasts/toasts.module.css
@@ -3,7 +3,7 @@
   top: 6rem;
   right: 0;
 
-  z-index: 100;
+  z-index: 3000;
 
   max-width: min(70vw, 16rem);
 

--- a/src/context/call.context.tsx
+++ b/src/context/call.context.tsx
@@ -289,6 +289,11 @@ export const CallProvider = ({ children }: { children: React.ReactNode }) => {
     );
 
     roomIdRef.current = roomId;
+
+    bakeToast({
+      type: "success",
+      message: "Call started, Turn on Audio/Video!",
+    });
   };
 
   const rejectCall = () => {
@@ -410,6 +415,11 @@ export const CallProvider = ({ children }: { children: React.ReactNode }) => {
       roomIdRef.current = roomId;
       setIsInCall(true);
       setIsCallConnecting(false);
+
+      bakeToast({
+        type: "success",
+        message: "Call started, Turn on Audio/Video!",
+      });
     });
 
     socket.on(


### PR DESCRIPTION
This pull request includes several changes to the call functionality and user interface in the `src/components` and `src/context` directories. The most important changes include adding a spinner to indicate call connection status, updating the z-index of toast notifications, and displaying success messages when a call starts.

Enhancements to call connection status:

* [`src/components/call-central/call-central.tsx`](diffhunk://#diff-6f97d86c8ada95b0f9e300b9c2896a3b7771a15269c4ac98902821dce86efa3dR8): Added a `Spinner` component to indicate when a call is connecting. [[1]](diffhunk://#diff-6f97d86c8ada95b0f9e300b9c2896a3b7771a15269c4ac98902821dce86efa3dR8) [[2]](diffhunk://#diff-6f97d86c8ada95b0f9e300b9c2896a3b7771a15269c4ac98902821dce86efa3dR94-R100)

User interface improvements:

* [`src/components/toasts/toasts.module.css`](diffhunk://#diff-8dd60baae850de7904a025ffe7b5dbb5b416ef9a8d96b0ac95ab5cd44d4821e5L6-R6): Increased the `z-index` of toast notifications from 100 to 3000 to ensure they appear above other elements.

Toast notifications for call events:

* [`src/context/call.context.tsx`](diffhunk://#diff-cb98301780b96741ae4403aa4b4a57ec0fe86407512f72907de4cd75f3d40617R292-R296): Added a success toast notification when a call starts, prompting users to turn on audio/video. [[1]](diffhunk://#diff-cb98301780b96741ae4403aa4b4a57ec0fe86407512f72907de4cd75f3d40617R292-R296) [[2]](diffhunk://#diff-cb98301780b96741ae4403aa4b4a57ec0fe86407512f72907de4cd75f3d40617R418-R422)