### PR TITLE
feat: Update Call control positioning and Add No TURN comment

### DIFF
--- a/src/components/call-central/call-central.module.css
+++ b/src/components/call-central/call-central.module.css
@@ -151,7 +151,7 @@
   justify-content: space-evenly;
   align-items: center;
 
-  position: absolute;
+  position: fixed;
   bottom: 0.1rem;
 
   width: 100%;

--- a/src/components/call-central/call-central.tsx
+++ b/src/components/call-central/call-central.tsx
@@ -140,3 +140,5 @@ export const CallCentral = () => {
     </>
   );
 };
+
+// Important Note: WebRTC-based calls on this platform rely on peer-to-peer connections. If either device is behind a strict firewall or network with restricted NAT settings, the call may not connect successfully. In such cases, additional network configurations or TURN servers are required, which are not currently implemented on this platform.


### PR DESCRIPTION
This pull request includes changes to the `call-central` component to improve the positioning of the call central UI and add an important note about WebRTC-based calls.

UI improvements:

* [`src/components/call-central/call-central.module.css`](diffhunk://#diff-e055fe4f220c88a2eb8cf307ee79d2fb0b4188ab66703dc5712793335ea6ef7cL154-R154): Changed the `position` property from `absolute` to `fixed` to ensure the call central UI stays fixed at the bottom of the screen.

Documentation updates:

* [`src/components/call-central/call-central.tsx`](diffhunk://#diff-6f97d86c8ada95b0f9e300b9c2896a3b7771a15269c4ac98902821dce86efa3dR143-R144): Added a note explaining that WebRTC-based calls may fail if devices are behind strict firewalls or networks with restricted NAT settings, and that additional network configurations or TURN servers are required but not currently implemented.